### PR TITLE
Add live preview to watermark editor

### DIFF
--- a/CameraM/CameraViewController.m
+++ b/CameraM/CameraViewController.m
@@ -611,11 +611,11 @@
   [self.view layoutIfNeeded];
   CGFloat safeTop = self.view.safeAreaInsets.top;
   CGFloat availableHeight = screenHeight - safeTop - 24.0f;
-  CGFloat minimumHeight = 360.0f;
+  CGFloat minimumHeight = 520.0f;
   if (availableHeight < minimumHeight) {
     availableHeight = minimumHeight;
   }
-  CGFloat targetHeight = screenHeight * 0.7f;
+  CGFloat targetHeight = screenHeight * 0.82f;
   targetHeight = MIN(targetHeight, availableHeight);
   targetHeight = MAX(targetHeight, minimumHeight);
   return targetHeight;
@@ -647,6 +647,8 @@
 
   if (self.importCustomizationOverlay.superview) {
     [self.importWatermarkPanel applyConfiguration:configuration animated:NO];
+    [self.importWatermarkPanel updatePreviewWithImage:self.pendingImportedImage
+                                            metadata:self.pendingImportMetadata];
     self.pendingImportConfiguration = [configuration copy];
     return;
   }
@@ -669,6 +671,8 @@
   panel.translatesAutoresizingMaskIntoConstraints = NO;
   panel.delegate = self;
   [panel applyConfiguration:configuration animated:NO];
+  [panel updatePreviewWithImage:self.pendingImportedImage
+                       metadata:self.pendingImportMetadata];
 
   UIStackView *buttons = [[UIStackView alloc] init];
   buttons.translatesAutoresizingMaskIntoConstraints = NO;

--- a/CameraM/Views/CameraControlsView.m
+++ b/CameraM/Views/CameraControlsView.m
@@ -552,6 +552,7 @@ static const CGFloat CMModeSelectorWidth = 60.0f;
   self.watermarkPanel.translatesAutoresizingMaskIntoConstraints = NO;
   self.watermarkPanel.delegate = self;
   self.watermarkPanel.hidden = YES;
+  [self.watermarkPanel updatePreviewWithImage:nil metadata:nil];
   [self addSubview:self.watermarkPanel];
 
   self.watermarkPanelBottomConstraint = [self.watermarkPanel.bottomAnchor
@@ -573,8 +574,8 @@ static const CGFloat CMModeSelectorWidth = 60.0f;
 
 - (CGFloat)desiredWatermarkPanelHeight {
   CGFloat screenHeight = UIScreen.mainScreen.bounds.size.height;
-  CGFloat targetHeight = screenHeight * 0.7f;
-  CGFloat minimumHeight = 360.0f;
+  CGFloat targetHeight = screenHeight * 0.82f;
+  CGFloat minimumHeight = 520.0f;
   CGFloat availableHeight = screenHeight - self.safeAreaInsets.top - 24.0f;
   if (availableHeight < minimumHeight) {
     availableHeight = minimumHeight;

--- a/CameraM/Views/WatermarkPanelView.h
+++ b/CameraM/Views/WatermarkPanelView.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)applyConfiguration:(CMWatermarkConfiguration *)configuration animated:(BOOL)animated;
 - (void)setPanelEnabled:(BOOL)enabled animated:(BOOL)animated;
+- (void)updatePreviewWithImage:(nullable UIImage *)image metadata:(nullable NSDictionary *)metadata;
 
 @end
 


### PR DESCRIPTION
## Summary
- embed a full-width preview canvas in `WatermarkPanelView` with async watermark rendering and larger option icons
- update the camera controls and import flow to feed selected photos into the panel and tune panel sizing for the new layout

## Testing
- xcodebuild -project CameraM.xcodeproj -scheme CameraM -sdk iphonesimulator build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d8ace7cea4832494053d5dcc570912